### PR TITLE
Add bamoe-bom dependency also as a direct dependency

### DIFF
--- a/runtime-libraries/maven-repository-zip/pom.xml
+++ b/runtime-libraries/maven-repository-zip/pom.xml
@@ -32,6 +32,12 @@
   <dependencies>
     <dependency>
       <groupId>com.ibm.bamoe</groupId>
+      <artifactId>bamoe-bom</artifactId>
+      <type>pom</type>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.bamoe</groupId>
       <artifactId>bamoe-ilmt-compliance-quarkus-pamoe</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixes https://github.com/IBM/kie-roadmap/issues/165

It needs to be as a hard dependency, not just as an import to be in the Maven repository zip. 