### PR TITLE
Add configuration for Maven Central deploy.

### DIFF
--- a/runtime-libraries/pom.xml
+++ b/runtime-libraries/pom.xml
@@ -15,6 +15,10 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
+    <gpg.plugin.version>3.1.0</gpg.plugin.version>
+
     <version.org.kogito>2.0.0-SNAPSHOT</version.org.kogito>
     <version.org.drools>8.41.0-SNAPSHOT</version.org.drools>
   </properties>
@@ -41,18 +45,13 @@
     </developer>
   </developers>
 
+  <modules>
+    <module>bom</module>
+    <module>build-parent</module>
+    <module>ilmt-compliance</module>
+  </modules>
+
   <profiles>
-    <profile>
-      <id>default</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <modules>
-        <module>bom</module>
-        <module>build-parent</module>
-        <module>ilmt-compliance</module>
-      </modules>
-    </profile>
     <profile>
       <id>build-maven-repo</id>
       <activation>
@@ -66,6 +65,49 @@
         <module>ilmt-compliance</module>
         <module>maven-repository-zip</module>
       </modules>
+    </profile>
+    <profile>
+      <id>release-maven-central</id>
+      <activation>
+        <property>
+          <name>release-maven-central</name>
+        </property>
+      </activation>
+      <distributionManagement>
+        <repository>
+          <id>ossrh</id>
+          <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${gpg.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>${nexus.staging.plugin.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Adds basic configuration for GPG code signing and staging deploy to Maven Central. 
- Note: autoReleaseAfterClose=false means that when uploaded to staging repository on Maven Central, the artifacts are not released automatically after they pass checks. We can change this default in the future if needed. I set it up currently to avoid accidental releases and to require manual verification of staging repositories before public Central release. 