### PR TITLE
[FIX] Add `kogito-addons-quarkus-job-http-recipient` & `kogito-addons-quarkus-job-sink-recipient` extensions to the `bamoe-bom`.

### DIFF
--- a/runtime-libraries/maven-repository-zip/pom.xml
+++ b/runtime-libraries/maven-repository-zip/pom.xml
@@ -1100,6 +1100,22 @@
       <groupId>org.kie</groupId>
       <artifactId>kogito-addons-quarkus-jobs-knative-eventing-deployment</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kogito-addons-quarkus-job-http-recipient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kogito-addons-quarkus-job-http-recipient-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kogito-addons-quarkus-job-sink-recipient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kogito-addons-quarkus-job-sink-recipient-deployment</artifactId>
+    </dependency>
 
     <!-- Runtime Persistence -->
     <dependency>
@@ -1271,6 +1287,10 @@
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kogito-addons-jobs-management-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>job-recipient-common-http</artifactId>
     </dependency>
 
     <!-- Data Audit -->

--- a/runtime-libraries/techpreview-bom/pom.xml
+++ b/runtime-libraries/techpreview-bom/pom.xml
@@ -375,6 +375,52 @@
         <classifier>sources</classifier>
       </dependency>
 
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kogito-addons-quarkus-job-http-recipient</artifactId>
+        <version>${version.org.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kogito-addons-quarkus-job-http-recipient</artifactId>
+        <version>${version.org.kogito}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kogito-addons-quarkus-job-http-recipient-deployment</artifactId>
+        <version>${version.org.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kogito-addons-quarkus-job-http-recipient-deployment</artifactId>
+        <version>${version.org.kogito}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kogito-addons-quarkus-job-sink-recipient</artifactId>
+        <version>${version.org.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kogito-addons-quarkus-job-sink-recipient</artifactId>
+        <version>${version.org.kogito}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kogito-addons-quarkus-job-sink-recipient-deployment</artifactId>
+        <version>${version.org.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kogito-addons-quarkus-job-sink-recipient-deployment</artifactId>
+        <version>${version.org.kogito}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <!-- Data Audit -->
       <dependency>
         <groupId>org.kie</groupId>
@@ -710,6 +756,17 @@
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>kogito-addons-jobs-management-common</artifactId>
+        <version>${version.org.kogito}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>job-recipient-common-http</artifactId>
+        <version>${version.org.kogito}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>job-recipient-common-http</artifactId>
         <version>${version.org.kogito}</version>
         <classifier>sources</classifier>
       </dependency>


### PR DESCRIPTION
Explicitly adding the extensions dependencies in the in the `bamoe-tech-preview` to help the quarkus maven plugin use the right `-deployment` artifact.

The `-runtime` artiracts for this two extensions were transitively brought to the to the maven repo  assembly by our colocated jobs service addon, the problem is that the quarkus maven plugin couldn't find the `-deployment` artifacts and it was downloading them. 