### PR TITLE
Download also asc signature files to Maven repository zip.

### DIFF
--- a/runtime-libraries/maven-repository-zip/maven-repository-zip-assembly-bamoe-only.xml
+++ b/runtime-libraries/maven-repository-zip/maven-repository-zip-assembly-bamoe-only.xml
@@ -18,6 +18,7 @@
         <exclude>**/_remote.repositories</exclude>
         <exclude>**/maven-metadata**</exclude>
         <exclude>**/resolver-status.properties</exclude>
+        <exclude>**/*.lastUpdated</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/runtime-libraries/maven-repository-zip/maven-repository-zip-assembly.xml
+++ b/runtime-libraries/maven-repository-zip/maven-repository-zip-assembly.xml
@@ -15,6 +15,7 @@
         <exclude>**/_remote.repositories</exclude>
         <exclude>**/maven-metadata**</exclude>
         <exclude>**/resolver-status.properties</exclude>
+        <exclude>**/*.lastUpdated</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/runtime-libraries/maven-repository-zip/pom.xml
+++ b/runtime-libraries/maven-repository-zip/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <m2.repo.location>${settings.localRepository}</m2.repo.location>
     <maven.repo.assembly.xml>maven-repository-zip-assembly-bamoe-only.xml</maven.repo.assembly.xml>
+    <version.ppgverify.plugin>1.17.0</version.ppgverify.plugin>
   </properties>
 
   <dependencyManagement>
@@ -1319,6 +1320,19 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.simplify4u.plugins</groupId>
+        <artifactId>pgpverify-maven-plugin</artifactId>
+        <version>${version.ppgverify.plugin}</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>go-offline</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
Fixes the problem, that Maven doesn't download signature files, when resolving dependencies, so they are missing in the Maven repository zip. 

Included new plugin (1) has Apache license and is developed by a Maven PMC Member. 

(1) https://github.com/s4u/pgpverify-maven-plugin