### PR TITLE
NO-ISSUE: Align BAMOE Developer Tools for VS Code with the new `tsconfig.json` files of `kie-tools` after TypeScript 5 upgrade

### DIFF
--- a/bamoe-developer-tools-for-vscode/kie-tools-package/tsconfig.json
+++ b/bamoe-developer-tools-for-vscode/kie-tools-package/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "@kie-tools/tsconfig/tsconfig.json",
+  "extends": "@kie-tools/tsconfig/tsconfig.cjs.json",
   "compilerOptions": {
     "declaration": false,
     "declarationMap": false
-  },
-  "include": ["src"]
+  }
 }


### PR DESCRIPTION
Not doing so is causing failures to happen during the build, as some packages are required to still be in CommonJS.