### PR TITLE
Remove @kie-tools-core/backend dependency from bamoe-developer-tools-for-vscode

### DIFF
--- a/bamoe-developer-tools-for-vscode/kie-tools-package/package.json
+++ b/bamoe-developer-tools-for-vscode/kie-tools-package/package.json
@@ -24,7 +24,6 @@
     "run:webmode": "pnpm vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --version=stable"
   },
   "dependencies": {
-    "@kie-tools-core/backend": "workspace:*",
     "@kie-tools-core/editor": "workspace:*",
     "@kie-tools-core/i18n": "workspace:*",
     "@kie-tools-core/patternfly-base": "workspace:*",


### PR DESCRIPTION
Should've been done as part of https://github.com/IBM/bamoe/pull/80. 