### PR TITLE
[incubator-kie-issues#1485 - Add column tasks.external_reference_id

### DIFF
--- a/bamoe-ddl/postgresql/data-index.sql
+++ b/bamoe-ddl/postgresql/data-index.sql
@@ -180,7 +180,8 @@ CREATE TABLE tasks (
     root_process_id character varying(255),
     root_process_instance_id character varying(255),
     started timestamp without time zone,
-    state character varying(255)
+    state character varying(255),
+    external_reference_id character varying(4000)
 );
 
 -- TABLE tasks_admin_groups: user task instance admin groups assigned


### PR DESCRIPTION
This fix adds the following changes to `data-index.sql`:
https://github.com/apache/incubator-kie-kogito-apps/blob/main/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.45.0.5__add_external_reference_id.sql