### PR TITLE
DBACLD-158721: add canvas-docker-compose.yaml

### DIFF
--- a/compose/canvas-docker-compose.yaml
+++ b/compose/canvas-docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
-  kie_canvas:
-    container_name: kie_canvas
+  bamoe_canvas:
+    container_name: bamoe_canvas
     image: "quay.io/bamoe/canvas:${BAMOE_VERSION}"
     ports:
       - 9090:8080
@@ -9,15 +9,15 @@ services:
       KIE_SANDBOX_EXTENDED_SERVICES_URL: "http://localhost:21345"
       KIE_SANDBOX_CORS_PROXY_URL: "http://localhost:7081"
     depends_on:
-      - extended_services
-      - cors_proxy
-  extended_services:
-    container_name: extended_services
+      - bamoe_extended_services
+      - bamoe_cors_proxy
+  bamoe_extended_services:
+    container_name: bamoe_extended_services
     image: "quay.io/bamoe/extended-services:${BAMOE_VERSION}"
     ports:
       - 21345:21345
-  cors_proxy:
-    container_name: cors_proxy
+  bamoe_cors_proxy:
+    container_name: bamoe_cors_proxy
     image: "quay.io/bamoe/cors-proxy:${BAMOE_VERSION}"
     ports:
       - 7081:8080

--- a/compose/canvas-docker-compose.yaml
+++ b/compose/canvas-docker-compose.yaml
@@ -1,0 +1,23 @@
+version: "3.8"
+services:
+  kie_canvas:
+    container_name: kie_canvas
+    image: "quay.io/bamoe/canvas:${BAMOE_VERSION}"
+    ports:
+      - 9090:8080
+    environment:
+      KIE_SANDBOX_EXTENDED_SERVICES_URL: "http://localhost:21345"
+      KIE_SANDBOX_CORS_PROXY_URL: "http://localhost:7081"
+    depends_on:
+      - extended_services
+      - cors_proxy
+  extended_services:
+    container_name: extended_services
+    image: "quay.io/bamoe/extended-services:${BAMOE_VERSION}"
+    ports:
+      - 21345:21345
+  cors_proxy:
+    container_name: cors_proxy
+    image: "quay.io/bamoe/cors-proxy:${BAMOE_VERSION}"
+    ports:
+      - 7081:8080


### PR DESCRIPTION
Adding canvas-docker-compose.yaml file into compose folder.

The ${BAMOE_VERSION} for an ad-hoc build can be provided as:
```
BAMOE_VERSION=9.1.1-ibm-0003 docker compose -f canvas-docker-compose.yaml up
```
While if desirable the yaml can be processed using yq to have those variables expanded:
```
yq -i  '(.. | select(tag == "!!str")) |= envsubst' canvas-docker-compose.yaml
```
which expands all env variables (but can be done also selectively).

This way, when desirable, perhaps other parts could be parameterized, like registry or so.