### PR TITLE
[DBACLD-167914] Increase column size for variable_value in data-audit SQL's

### DIFF
--- a/bamoe-kie-flyway-migrations/kogito-apps/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/microsoft-sql-server/V1.4.0__create_data_audit_storage_sqlserver_bamoe920.sql
+++ b/bamoe-kie-flyway-migrations/kogito-apps/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/microsoft-sql-server/V1.4.0__create_data_audit_storage_sqlserver_bamoe920.sql
@@ -133,7 +133,7 @@ CREATE TABLE process_instance_variable_log (
     root_process_instance_id character varying(255),
     variable_id character varying(255),
     variable_name character varying(255),
-    variable_value character varying(max),
+    variable_value varchar(max),
     CONSTRAINT process_instance_variable_log_pkey PRIMARY KEY (id)
 );
 
@@ -280,7 +280,7 @@ CREATE TABLE task_instance_variable_log (
     variable_id character varying(255),
     variable_name character varying(255),
     variable_type character varying(255),
-    variable_value character varying(max),
+    variable_value varchar(max),
     CONSTRAINT task_instance_variable_log_pkey PRIMARY KEY (id),
     CONSTRAINT task_instance_variable_log_variable_type_check CHECK (variable_type IN ('INPUT', 'OUTPUT'))
 );

--- a/bamoe-kie-flyway-migrations/kogito-apps/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/microsoft-sql-server/V1.4.0__create_data_audit_storage_sqlserver_bamoe920.sql
+++ b/bamoe-kie-flyway-migrations/kogito-apps/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/microsoft-sql-server/V1.4.0__create_data_audit_storage_sqlserver_bamoe920.sql
@@ -133,7 +133,7 @@ CREATE TABLE process_instance_variable_log (
     root_process_instance_id character varying(255),
     variable_id character varying(255),
     variable_name character varying(255),
-    variable_value character varying(255),
+    variable_value character varying(max),
     CONSTRAINT process_instance_variable_log_pkey PRIMARY KEY (id)
 );
 
@@ -280,7 +280,7 @@ CREATE TABLE task_instance_variable_log (
     variable_id character varying(255),
     variable_name character varying(255),
     variable_type character varying(255),
-    variable_value character varying(255),
+    variable_value character varying(max),
     CONSTRAINT task_instance_variable_log_pkey PRIMARY KEY (id),
     CONSTRAINT task_instance_variable_log_variable_type_check CHECK (variable_type IN ('INPUT', 'OUTPUT'))
 );

--- a/bamoe-kie-flyway-migrations/kogito-apps/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/microsoft-sql-server/V1.45.1.0__create_data_index_storage_sqlserver_bamoe920.sql
+++ b/bamoe-kie-flyway-migrations/kogito-apps/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/microsoft-sql-server/V1.45.1.0__create_data_index_storage_sqlserver_bamoe920.sql
@@ -27,16 +27,6 @@ CREATE TABLE definitions_annotations (
     CONSTRAINT fk_definitions_annotations FOREIGN KEY (process_id, process_version) REFERENCES process_definitions(id, version) ON DELETE CASCADE
 );
 
-CREATE TABLE definitions_metadata (
-    process_id character varying(255) NOT NULL,
-    process_version character varying(255) NOT NULL,
-    meta_value character varying(255),
-    name character varying(255) NOT NULL,
-    CONSTRAINT definitions_metadata_pkey PRIMARY KEY (process_id, process_version, name),
-    CONSTRAINT fk_definitions_metadata FOREIGN KEY (process_id, process_version) REFERENCES process_definitions(id, version) ON DELETE CASCADE
-
-);
-
 CREATE TABLE definitions_nodes (
     id character varying(255) NOT NULL,
     name character varying(255),
@@ -237,8 +227,6 @@ CREATE INDEX idx_attachments_tid ON attachments (task_id)
 CREATE INDEX idx_definitions_addons_pid_pv ON definitions_addons (process_id, process_version);
 
 CREATE INDEX idx_definitions_annotations_pid_pv ON definitions_annotations (process_id, process_version);
-
-CREATE INDEX idx_definitions_metadata_pid_pv ON definitions_metadata (process_id, process_version);
 
 CREATE INDEX idx_definitions_nodes_metadata_pid_pv ON definitions_nodes_metadata (process_id, process_version);
 

--- a/bamoe-kie-flyway-migrations/kogito-apps/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/microsoft-sql-server/V1.45.1.0__create_data_index_storage_sqlserver_bamoe920.sql
+++ b/bamoe-kie-flyway-migrations/kogito-apps/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/microsoft-sql-server/V1.45.1.0__create_data_index_storage_sqlserver_bamoe920.sql
@@ -7,6 +7,7 @@ CREATE TABLE process_definitions (
     source varbinary(max),
     endpoint character varying(255),
     description character varying(255),
+    metadata varchar(max),
     CONSTRAINT definitions_pkey PRIMARY KEY (id, version)
 );
 


### PR DESCRIPTION
 increased the size of the variable_values in data-audit tables (Process_Instance_Variable_Log & Task_Instance_Variable_Log) which are a varchar(255) and cannot store variables that are longer than 255 chars, and in the case of having Java Objects it's quite easy to reach that size.