### PR TITLE
Add `.gitignore` to `examples/`

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+target


### PR DESCRIPTION
Prevents `target` and `.DS_Store` files to be mistakenly pushed.