### PR TITLE
[DBACLD-168548] Create new ILMT libraries for Spring Boot

### DIFF
--- a/runtime-libraries/bom/pom.xml
+++ b/runtime-libraries/bom/pom.xml
@@ -67,6 +67,40 @@
         <version>${project.version}</version>
         <classifier>javadoc</classifier>
       </dependency>
+      <dependency>
+        <groupId>com.ibm.bamoe</groupId>
+        <artifactId>bamoe-ilmt-compliance-springboot-pamoe</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ibm.bamoe</groupId>
+        <artifactId>bamoe-ilmt-compliance-springboot-pamoe</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.ibm.bamoe</groupId>
+        <artifactId>bamoe-ilmt-compliance-springboot-pamoe</artifactId>
+        <version>${project.version}</version>
+        <classifier>javadoc</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.ibm.bamoe</groupId>
+        <artifactId>bamoe-ilmt-compliance-springboot-dmoe</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.ibm.bamoe</groupId>
+        <artifactId>bamoe-ilmt-compliance-springboot-dmoe</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.ibm.bamoe</groupId>
+        <artifactId>bamoe-ilmt-compliance-springboot-dmoe</artifactId>
+        <version>${project.version}</version>
+        <classifier>javadoc</classifier>
+      </dependency>
 
       <!-- Start of BAMOE database support-->
 

--- a/runtime-libraries/build-parent/pom.xml
+++ b/runtime-libraries/build-parent/pom.xml
@@ -20,6 +20,7 @@
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>3.15.3</quarkus.platform.version>
+    <springframework.boot.version>3.4.2</springframework.boot.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.3.1</surefire-plugin.version>
     <jandex-plugin.version>3.2.3</jandex-plugin.version>
@@ -36,6 +37,13 @@
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>
         <version>${quarkus.platform.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${springframework.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/pom.xml
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.ibm.bamoe</groupId>
+        <artifactId>bamoe-ilmt-compliance</artifactId>
+        <version>9.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bamoe-ilmt-compliance-springboot-dmoe</artifactId>
+    <name>Business Automation Manager Open Editions - ILMT Compliance DMOE</name>
+    <description>IBM BAMOE ILMT compliance library for DMOE use cases and applications.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.ibm.bamoe</groupId>
+            <artifactId>bamoe-ilmt-compliance-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/readme.md
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/readme.md
@@ -1,0 +1,16 @@
+# This is a DMOE ILMT compliance library that every DMOE project should use.
+
+This library uses the system variable SWIDTAG_DIR to determine the directory for creating a swidtag file. If the SWIDTAG_DIR variable is set, the library will use the specified directory for swidtag file creation. In cases where SWIDTAG_DIR is not set the library will default to the home directory of the hosting application.
+
+It's important to note that if the SWIDTAG_DIR environment variable contains invalid content or an invalid path, the hosting application will fail to deploy.
+
+The swidtag file is an XML file content based on ISO/IEC 19770-2:2015 specification. Here’s an example of the swidtag file content:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<SoftwareIdentity name="IBM Decision Manager Open Edition" tagId="ibm.com-3d9d28f19d0f45fda113c07fb481e3ea-9.0.0" version="9.0.0" versionScheme="multipartnumeric" xml:lang="en" xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.iso.org/iso/19770/-2/2015-current/schema.xsd schema.xsd">
+    <Meta persistentId="3d9d28f19d0f45fda113c07fb481e3ea"/>
+    <Meta generator="4-1-20210113"/>
+    <Entity name="IBM" regid="ibm.com" role="licensor tagCreator softwareCreator"/>
+</SoftwareIdentity>
+```

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/src/main/java/com/ibm/bamoe/ilmt/springboot/dmoe/DMOESwidTagGen.java
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/src/main/java/com/ibm/bamoe/ilmt/springboot/dmoe/DMOESwidTagGen.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright IBM Corp. 2025
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.bamoe.ilmt.springboot.dmoe;
+
+import com.ibm.bamoe.ilmt.common.SwidFileGenerator;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DMOESwidTagGen extends SwidFileGenerator {
+
+    public DMOESwidTagGen() {
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void createSwidFile(ApplicationReadyEvent event) {
+        super.createSwidFile();
+    }
+
+    public String getFileName() {
+        return "ibm.com_IBM_Decision_Manager_Open_Edition-9.1.1.swidtag";
+    }
+
+    @Override
+    public String getSwidContent() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                "<SoftwareIdentity xmlns=\"http://standards.iso.org/iso/19770/-2/2015/schema.xsd\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" name=\"IBM Decision Manager Open Edition\" tagId=\"ibm.com-a46f72acb4204f1c8b27228722103341-9.1.1\" version=\"9.1.1\" versionScheme=\"multipartnumeric\" xml:lang=\"en\" xsi:schemaLocation=\"http://standards.iso.org/iso/19770/-2/2015-current/schema.xsd schema.xsd\">\n" +
+                "    <Meta persistentId=\"a46f72acb4204f1c8b27228722103341\"/>\n" +
+                "    <Meta generator=\"4-1-20210113\"/>\n" +
+                "    <Entity name=\"IBM\" regid=\"ibm.com\" role=\"licensor tagCreator softwareCreator\"/>\n" +
+                "</SoftwareIdentity>";
+    }
+}

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/src/test/java/com/ibm/bamoe/ilmt/springboot/dmoe/DMOESwidTagGenTest.java
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/src/test/java/com/ibm/bamoe/ilmt/springboot/dmoe/DMOESwidTagGenTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright IBM Corp. 2023
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.bamoe.ilmt.springboot.dmoe;
+
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = SpringbootTestApplication.class)
+public class DMOESwidTagGenTest {
+
+    @Autowired
+    DMOESwidTagGen swidFileGenerator;
+
+    @AfterEach
+    public void cleanup() throws IOException {
+        Files.deleteIfExists(swidFileGenerator.getFilePath());
+    }
+
+    @Test
+    public void testGenerateSwidFile() throws IOException {
+        assertTrue(Files.exists(swidFileGenerator.getFilePath()), "SWID file should be generated");
+
+        String swidContent = Files.readString(swidFileGenerator.getFilePath());
+        assertEquals(swidFileGenerator.getSwidContent(), swidContent, "SWID file content should match expected content");
+    }
+
+}

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/src/test/java/com/ibm/bamoe/ilmt/springboot/dmoe/SpringbootTestApplication.java
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-dmoe/src/test/java/com/ibm/bamoe/ilmt/springboot/dmoe/SpringbootTestApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ibm.bamoe.ilmt.springboot.dmoe;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = { "com.ibm.bamoe.ilmt.springboot.dmoe" })
+public class SpringbootTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SpringbootTestApplication.class, args);
+    }
+}

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/pom.xml
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.ibm.bamoe</groupId>
+        <artifactId>bamoe-ilmt-compliance</artifactId>
+        <version>9.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bamoe-ilmt-compliance-springboot-pamoe</artifactId>
+    <name>Business Automation Manager Open Editions - ILMT Compliance PAMOE</name>
+    <description>IBM BAMOE ILMT compliance library for PAMOE use cases and applications.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.ibm.bamoe</groupId>
+            <artifactId>bamoe-ilmt-compliance-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+    
+</project>

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/readme.md
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/readme.md
@@ -1,0 +1,16 @@
+# This is a PAMOE ILMT compliance library that every PAMOE  project should use.
+
+This library uses the system variable SWIDTAG_DIR to determine the directory for creating a swidtag file. If the SWIDTAG_DIR variable is set, the library will use the specified directory for swidtag file creation. In cases where SWIDTAG_DIR is not set the library will default to the home directory of the hosting application.
+
+It's important to note that if the SWIDTAG_DIR environment variable contains invalid content or an invalid path, the hosting application will fail to deploy.
+
+The swidtag file is an XML file content based on ISO/IEC 19770-2:2015 specification. Here’s an example of the swidtag file content:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<SoftwareIdentity name="IBM Process Automation Manager Open Edition" tagId="ibm.com-3d9d28f19d0f45fda113c07fb481e3ea-9.0.0" version="9.0.0" versionScheme="multipartnumeric" xml:lang="en" xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.iso.org/iso/19770/-2/2015-current/schema.xsd schema.xsd">
+    <Meta persistentId="3d9d28f19d0f45fda113c07fb481e3ea"/>
+    <Meta generator="4-1-20210113"/>
+    <Entity name="IBM" regid="ibm.com" role="licensor tagCreator softwareCreator"/>
+</SoftwareIdentity>
+```

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/src/main/java/com/ibm/bamoe/ilmt/springboot/pamoe/PAMOESwidTagGen.java
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/src/main/java/com/ibm/bamoe/ilmt/springboot/pamoe/PAMOESwidTagGen.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright IBM Corp. 2025
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.bamoe.ilmt.springboot.pamoe;
+
+import com.ibm.bamoe.ilmt.common.SwidFileGenerator;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PAMOESwidTagGen extends SwidFileGenerator {
+
+    public PAMOESwidTagGen() {
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void createSwidFile(ApplicationReadyEvent event) {
+        super.createSwidFile();
+    }
+
+    public String getFileName() {
+        return "ibm.com_IBM_Process_Automation_Manager_Open_Edition-9.1.1.swidtag";
+    }
+
+    @Override
+    public String getSwidContent() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                "<SoftwareIdentity xmlns=\"http://standards.iso.org/iso/19770/-2/2015/schema.xsd\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" name=\"IBM Process Automation Manager Open Edition\" tagId=\"ibm.com-3d9d28f19d0f45fda113c07fb481e3ea-9.1.1\" version=\"9.1.1\" versionScheme=\"multipartnumeric\" xml:lang=\"en\" xsi:schemaLocation=\"http://standards.iso.org/iso/19770/-2/2015-current/schema.xsd schema.xsd\">\n" +
+                "    <Meta persistentId=\"3d9d28f19d0f45fda113c07fb481e3ea\"/>\n" +
+                "    <Meta generator=\"4-1-20210113\"/>\n" +
+                "    <Entity name=\"IBM\" regid=\"ibm.com\" role=\"licensor tagCreator softwareCreator\"/>\n" +
+                "</SoftwareIdentity>";
+    }
+}

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/src/test/java/com/ibm/bamoe/ilmt/springboot/pamoe/PAMOESwidTagGenTest.java
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/src/test/java/com/ibm/bamoe/ilmt/springboot/pamoe/PAMOESwidTagGenTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright IBM Corp. 2023
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.bamoe.ilmt.springboot.pamoe;
+
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = SpringbootTestApplication.class)
+public class PAMOESwidTagGenTest {
+
+    @Autowired
+    PAMOESwidTagGen swidFileGenerator;
+
+    @AfterEach
+    public void cleanup() throws IOException {
+        Files.deleteIfExists(swidFileGenerator.getFilePath());
+    }
+
+    @Test
+    public void testGenerateSwidFile() throws IOException {
+        assertTrue(Files.exists(swidFileGenerator.getFilePath()), "SWID file should be generated");
+
+        String swidContent = Files.readString(swidFileGenerator.getFilePath());
+        assertEquals(swidFileGenerator.getSwidContent(), swidContent, "SWID file content should match expected content");
+    }
+
+}

--- a/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/src/test/java/com/ibm/bamoe/ilmt/springboot/pamoe/SpringbootTestApplication.java
+++ b/runtime-libraries/ilmt-compliance/ilmt-compliance-springboot-pamoe/src/test/java/com/ibm/bamoe/ilmt/springboot/pamoe/SpringbootTestApplication.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.ibm.bamoe.ilmt.springboot.pamoe;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = { "com.ibm.bamoe.ilmt.springboot.pamoe" })
+public class SpringbootTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SpringbootTestApplication.class, args);
+    }
+}

--- a/runtime-libraries/ilmt-compliance/pom.xml
+++ b/runtime-libraries/ilmt-compliance/pom.xml
@@ -20,6 +20,8 @@
     <module>ilmt-compliance-common</module>
     <module>ilmt-compliance-quarkus-pamoe</module>
     <module>ilmt-compliance-quarkus-dmoe</module>
+    <module>ilmt-compliance-springboot-pamoe</module>
+    <module>ilmt-compliance-springboot-dmoe</module>
   </modules>
 
 </project>

--- a/runtime-libraries/maven-repository-zip/pom.xml
+++ b/runtime-libraries/maven-repository-zip/pom.xml
@@ -92,6 +92,34 @@
       <artifactId>bamoe-ilmt-compliance-quarkus-dmoe</artifactId>
       <classifier>javadoc</classifier>
     </dependency>
+    <dependency>
+      <groupId>com.ibm.bamoe</groupId>
+      <artifactId>bamoe-ilmt-compliance-springboot-pamoe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.bamoe</groupId>
+      <artifactId>bamoe-ilmt-compliance-springboot-pamoe</artifactId>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.bamoe</groupId>
+      <artifactId>bamoe-ilmt-compliance-springboot-pamoe</artifactId>
+      <classifier>javadoc</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.bamoe</groupId>
+      <artifactId>bamoe-ilmt-compliance-springboot-dmoe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.bamoe</groupId>
+      <artifactId>bamoe-ilmt-compliance-springboot-dmoe</artifactId>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.bamoe</groupId>
+      <artifactId>bamoe-ilmt-compliance-springboot-dmoe</artifactId>
+      <classifier>javadoc</classifier>
+    </dependency>
 
     <dependency>
       <groupId>org.kie.kogito</groupId>


### PR DESCRIPTION
Create Spring-boot specific ILMT libraries and declare them in pom.

Caveat:

1. the `swidtag` files are generated only when the springboot application start; inside CI, this happen when tests are executed, but a couple of examples (dmn-15-{quarkus|springboot}-example) does not have tests, so the file are not generated for theme
2. the creation logic has been delegated to a `Component` that has an `EventListener(ApplicationReadyEvent.class)` method, that is invoked when the application start
3. for testing purposes, a `SpringbootTestApplication` has been implemented, under test directory, to load the listening bean
4. the listening bean has been created under the package `com.ibm.bamoe.ilmt.springboot.{dmoe|pamoe}`, so the `KogitoSpringbootApplication` class in the springboot examples has to be modified to also scan the above package

`@SpringBootApplication(scanBasePackages = { "org.kie.kogito.dmn.**", "org.kie.kogito.app.**", "http**", "com.ibm.bamoe.ilmt.springboot.dmoe" })`

