### PR TITLE
DBACLD-174024 : Fix Quarkus profiles in Process Persistence Example

### DIFF
--- a/examples/process-persistence/README.md
+++ b/examples/process-persistence/README.md
@@ -295,16 +295,16 @@ docker compose -f ./docker-compose/docker-compose-<dbtype>.yml down
 
 ### Running in Development mode
 
-The development mode in this application currently supports three databases: `h2`, `postgresql`, `mssql` and `oracle`. The dev 
+The development mode in this application currently supports only `h2` database. The dev 
 mode will embed all the needed Infrastructure Services (Database, Data-Index & Jobs Service) and won't require any 
 extra step. To start this example's app in Development mode with a specific database configuration, just run the 
 following command in a terminal
 ```
 mvn clean package quarkus:dev -P<dbtype>
 ```
-So for e.g. to start the example in dev mode using `postgresql` database configuration we can run the following command:
+So for e.g. to start the example in dev mode using `h2` database configuration we can run the following command:
 ```shell
-mvn clean package quarkus:dev -Ppostgresql
+mvn clean package quarkus:dev -Ph2
 ```
 If we don't specify a profile, database configurations of h2 is used by default in dev mode.
 ```shell

--- a/examples/process-persistence/README.md
+++ b/examples/process-persistence/README.md
@@ -18,7 +18,7 @@
 # Example :: Process Persistence
 
 This example depicts the usage of persistence configuration for various databases like H2, Postgresql, MS SQL and Oracle. 
-This application can be run in dev and container modes.
+This application can be run in dev and in container modes.
 
 This example also showcases a basic implementation of a **Hiring** Process that drives a _Candidate_ through different
 interviews until they get hired. It features simple User Task orchestration including the use of DMN decisions to
@@ -30,17 +30,32 @@ example. You could find more details about that example from its README.
 ## Configuration
 
 As mentioned earlier, this example can be run in quarkus development mode and in container mode. In dev mode, the 
-example could use `h2`, `postgresql`, `mssql` or `oracle`. In container mode it can use `postgresql`, `mssql` or `oracle`.
+example uses `h2` database by default. In container mode it can use `postgresql`, `mssql` or `oracle` databases.
 
-Each database is paired with a maven profile and a quarkus profile which are tied together. So in this example there 
-are five maven profiles `h2`, `postgresql`, `mssql`, `oracle` and `container` tied to quarkus profiles with similar 
-name. `h2`, `postgresql`, `mssql` and `oracle` profiles defines their own specific database dependencies and configurations 
-whereas `container` profile defines the dependencies and configurations to pack the example as a docker image.
+The databases `postgresql`, `mssql`, `oracle` are paired with a maven profile and a quarkus profile which are tied together. 
+So in this example there are three maven profiles  `postgresql`, `mssql`  and `oracle` tied to quarkus profiles with similar 
+name. The `postgresql`, `mssql` and `oracle` profiles defines their own specific database dependencies and configurations 
+whereas the `container` dependency is configured by adding the `quarkus-container-image-jib` dependency to all the db profiles 
+which packs the example as a docker image.
 
 In Dev mode, Quarkus provides us with a zero config database out of the box, a feature referred to as Dev Services.
-The only configuration that needs to be defined is `quarkus.datasource.db-kind` and the only main dependency required 
-is the corresponding jdbc driver. Don’t configure a database URL, username and password if you intend to use Dev 
-Services. If you would still like to customize the database properties, you can refer 
+The only configuration that needs to be defined is `dev.quarkus.datasource.db-kind=h2` and the only main dependency required 
+is the corresponding jdbc driver which is included along with the common dependencies. Don’t configure a database URL, username and password if you intend to use Dev 
+Services. So H2 is the default database for dev mode. The only dependency needed is h2 jdbc driver.
+
+This is the configuration for H2
+```
+%dev.quarkus.datasource.db-kind=h2
+%dev.quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY
+
+```
+`quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY` is a generic property that is usually added
+to the database connection url. The flyway scripts defines tables with columns names like `key` and `value`. But
+these are reserved words when working with H2. So this property effectively allows to create columns with these
+names without any problems. 
+The H2 database runs in-process.
+
+If you would still like to customize the database properties, you can refer 
 [this](https://quarkus.io/version/3.15/guides/databases-dev-services#configuration-reference). More information about 
 Dev Services can be found [here](https://quarkus.io/version/3.15/guides/databases-dev-services).
 
@@ -59,42 +74,6 @@ implementation with integration with transaction and security.
 
 Let's take a look at each profile and the configurations in detail.
 
-### H2
-
-This is the maven profile for H2
-
-```
-<profile>
-    <id>h2</id>
-    <activation>
-        <activeByDefault>true</activeByDefault>
-    </activation>
-    <properties>
-        <quarkus.profile>h2</quarkus.profile>
-    </properties>
-    <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-h2</artifactId>
-        </dependency>
-    </dependencies>
-</profile>
-```
-So H2 is the default database if we don't specify any profile. The only dependency needed is h2 jdbc driver.
-
-This is the configuration for H2
-```
-%h2.quarkus.datasource.db-kind=h2
-%h2.quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY
-```
-
-`quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY` is a generic property that is usually added 
-to the database connection url. The flyway scripts defines tables with columns names like `key` and `value`. But 
-these are reserved words when working with H2. So this property effectively allows to create columns with these 
-names without any problems.
-
-The H2 database runs in-process.
-
 ### Postgresql
 
 This is the maven profile for Postgresql
@@ -109,18 +88,16 @@ This is the maven profile for Postgresql
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib</artifactId>
+        </dependency>
     </dependencies>
 </profile>
 ```
-The only dependency needed is postgresql jdbc driver.
-
-This is the configuration for Postgresql
-```
-%postgresql.quarkus.datasource.db-kind=postgresql
-```
-
-When running the example in Dev mode, Quarkus will stat a `Postgresql` database container as a part of the Dev
-Services. So make sure to install docker before running this example.
+The dependency needed are postgresql jdbc driver and `quarkus-container-image-jib`.
+The `quarkus-container-image-jib` is an extension for the Quarkus framework that enables 
+building container images using Jib and helps to build the optimized container images directly.
 
 ### MS SQL Server
 
@@ -141,19 +118,17 @@ This is the maven profile for MS SQL Server
             <artifactId>bamoe-mssql-mappings</artifactId>
             <version>${version.com.ibm.bamoe}</version>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib</artifactId>
+        </dependency>
     </dependencies>
 </profile>
 ```
-The dependencies needed are mssql jdbc driver and `bamoe-mssql-mappings`.
-
-This is the configuration for MS SQL Server
-```
-%mssql.quarkus.datasource.db-kind=mssql
-%mssql.quarkus.hibernate-orm.mapping-files=META-INF/bamoe-data-index-orm.xml,META-INF/bamoe-job-service-orm.xml
-```
+The dependencies needed are mssql jdbc driver , `bamoe-mssql-mappings` and `quarkus-container-image-jib`.
 
 The `bamoe-mssql-mappings` is a utility library to help Job Service and Data Index storage work properly with 
-`MS SQL Server`. It contains the hibernate orm.xml that will remap some of the JPA entities contained in both modules.
+`MS SQL Server`. It contains the Hibernate orm.xml that will remap some of the JPA entities contained in both modules.
 
 The available orm's are:
 - META-INF/bamoe-data-index-orm.xml: This file remaps some entities from the data-index component.
@@ -163,10 +138,6 @@ Depending on the dependencies configured in our application it may be required t
 To configure which mapping files should be imported you can use the `quarkus.hibernate-orm.mapping-files` property to 
 configure a comma-separated list of ORM files to use.
 
-When running the example in Dev mode, Quarkus will start a `MS SQL Server` database container as a part of the Dev 
-Services. So make sure to install docker before running this example. In order to use mssql database as a Dev Service 
-it also requires us to have a [license acceptance file](src/main/resources/container-license-acceptance.txt). More on
-this [here](https://quarkus.io/version/3.15/guides/databases-dev-services#license_acceptance).
 
 ### Oracle
 
@@ -187,19 +158,17 @@ This is the maven profile for Oracle
                 <artifactId>bamoe-oracle-mappings</artifactId> 
                 <version>${version}</version>
             </dependency>
+            <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-container-image-jib</artifactId>
+        </dependency>
         </dependencies>
     </profile>
 ```
-The dependencies needed are `oracle jdbc driver` and `bamoe-oracle-mappings`.
-
-This is the configuration for Oracle
-```
-%oracle.quarkus.datasource.db-kind=oracle
-%oracle.quarkus.hibernate-orm.mapping-files=META-INF/bamoe-user-task-orm.xml,META-INF/bamoe-job-service-orm.xml
-```
+The dependencies needed are `oracle jdbc driver` , `bamoe-oracle-mappings` and `quarkus-container-image-jib`.
 
 The `bamoe-oracle-mappings` is a utility library to help Job Service and User Task storage work properly with 
-`Oracle`. It contains the hibernate orm.xml that will remap some of the JPA entities contained in both modules.
+`Oracle`. It contains the Hibernate orm.xml that will remap some of the JPA entities contained in both modules.
 
 The available orm's are:
 - META-INF/bamoe-user-task-orm.xml: This file remaps some entities from the jbpm-usertask-storage-jpa component.
@@ -209,44 +178,14 @@ Depending on the dependencies configured in our application it may be required t
 To configure which mapping files should be imported you can use the `quarkus.hibernate-orm.mapping-files` property to 
 configure a comma-separated list of ORM files to use.
 
-When running the example in Dev mode, Quarkus will start a `Oracle` database container as a part of the Dev 
-Services. So make sure to install docker before running this example. 
-
 ### Container
 
-This is the container maven profile
-```
-<profile>
-    <id>container</id>
-    <properties>
-        <quarkus.profile>container</quarkus.profile>
-    </properties>
-    <dependencies>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-container-image-jib</artifactId>
-        </dependency>
-    </dependencies>
-</profile>
-```
 The `quarkus-container-image-jib` library is used to package the example as a docker image.
-
-This is the corresponding configuration
-```
-%container,postgresql,mssql,oracle.quarkus.container-image.build=true
-%container,postgresql,mssql,oracle.quarkus.container-image.push=false
-%container,postgresql,mssql,oracle.quarkus.container-image.group=bamoe
-%container,postgresql,mssql,oracle.quarkus.container-image.registry=dev.local
-%container,postgresql,mssql,oracle.quarkus.container-image.tag=${project.version}
-%postgresql.quarkus.container-image.name=process-persistence-postgresql
-%mssql.quarkus.container-image.name=process-persistence-mssql
-%oracle.quarkus.container-image.name=process-persistence-oracle
-```
-
-These are the configurations of the resulting image. The `container` profile is used in tandem with a database profile 
-like `postgresql` or `mssql` or`oracle` to pack related database dependencies and configurations. The resulting image is then 
-used in a docker compose file to run all services including this example, database and any other database addon 
-services together as containers. The docker compose files are located [here](docker-compose).
+The `container` related dependency `quarkus-container-image-jib` library is added in the corresponding 
+database profile like `postgresql` or `mssql`or`oracle` to pack related database dependencies and configurations. 
+The resulting image is then used in a docker compose file to run all services including this example, 
+database and any other database addon services together as containers.
+The docker compose files are located [here](docker-compose).
 
 ---
 
@@ -264,13 +203,13 @@ services together as containers. The docker compose files are located [here](doc
 First, build the example by running the following command in a terminal
 
 ```
-mvn clean package -Pcontainer,<dbtype>
+mvn clean package -P<dbtype>
 ```
 Current supported dbtypes in container mode are `postgresql`, `mssql` and `oracle`. So for e.g. to build the example using 
 postgresql database configuration we can run the following command
 
 ```shell
-mvn clean package -Pcontainer,postgresql
+mvn clean package -Ppostgresql
 ```
 This will build this example's Quarkus application with the corresponding database configuration and create a Docker 
 image that will be used in the `docker compose` template.

--- a/examples/process-persistence/README.md
+++ b/examples/process-persistence/README.md
@@ -272,7 +272,6 @@ group, registry, tag & name needed to build the image.
 %oracle.quarkus.container-image.name=process-persistence-oracle
 ```
 ---
-
 ## Running
 
 ### Prerequisites

--- a/examples/process-persistence/README.md
+++ b/examples/process-persistence/README.md
@@ -90,8 +90,8 @@ Below are the configurations needed for H2.
 ```
 The `%dev.quarkus.datasource.db-kind` configuration property is used to explicitly specify the type of database to connect. 
 `quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY` is a generic property that is usually added
-to the database connection url. The flyway scripts defines tables with columns names like `key` and `value`. But
-these are reserved words when working with H2. So this property effectively allows to create columns with these
+to the database connection url. The flyway scripts define tables with columns names like `key` and `value`. But
+these are reserved words when working with H2. So this property effectively allows creating columns with these
 names without any problems.
 The H2 database runs in-process.
 

--- a/examples/process-persistence/README.md
+++ b/examples/process-persistence/README.md
@@ -134,6 +134,17 @@ Below are the database configuration required for the Postgresql
 ```
 The `%postgresql.quarkus.datasource.db-kind` configuration property is used to explicitly specify the type of database to connect.
 
+Different properties configured using the `postgresql.quarkus.container-image` define image-related settings like
+group, registry, tag & name needed to build the image.
+
+```
+%postgresql.quarkus.container-image.build=true
+%postgresql.quarkus.container-image.push=false
+%postgresql.quarkus.container-image.group=bamoe
+%postgresql.quarkus.container-image.registry=dev.local
+%postgresql.quarkus.container-image.tag=${project.version}
+%postgresql.quarkus.container-image.name=process-persistence-postgresql
+```
 
 ### MS SQL Server
 
@@ -186,6 +197,17 @@ Depending on the dependencies configured in our application it may be required t
 To configure which mapping files should be imported you can use the `quarkus.hibernate-orm.mapping-files` property to
 configure a comma-separated list of ORM files to use.
 
+Different properties configured using the `mssql.quarkus.container-image` define image-related settings like
+group, registry, tag & name needed to build the image.
+
+```
+%mssql.quarkus.container-image.build=true
+%mssql.quarkus.container-image.push=false
+%mssql.quarkus.container-image.group=bamoe
+%mssql.quarkus.container-image.registry=dev.local
+%mssql.quarkus.container-image.tag=${project.version}
+%mssql.quarkus.container-image.name=process-persistence-mssql
+```
 
 ### Oracle
 
@@ -238,36 +260,6 @@ Depending on the dependencies configured in our application it may be required t
 To configure which mapping files should be imported you can use the `quarkus.hibernate-orm.mapping-files` property to 
 configure a comma-separated list of ORM files to use.
 
- Let's have a look into the  container specific configurations required for each profiles:
-
-### Postgresql
-
-Different properties configured using the `postgresql.quarkus.container-image` define image-related settings like
-group, registry, tag & name needed to build the image.
-
-```
-%postgresql.quarkus.container-image.build=true
-%postgresql.quarkus.container-image.push=false
-%postgresql.quarkus.container-image.group=bamoe
-%postgresql.quarkus.container-image.registry=dev.local
-%postgresql.quarkus.container-image.tag=${project.version}
-%postgresql.quarkus.container-image.name=process-persistence-postgresql
-```
-
-### MS SQL Server
-Different properties configured using the `mssql.quarkus.container-image` define image-related settings like
-group, registry, tag & name needed to build the image.
-
-```
-%mssql.quarkus.container-image.build=true
-%mssql.quarkus.container-image.push=false
-%mssql.quarkus.container-image.group=bamoe
-%mssql.quarkus.container-image.registry=dev.local
-%mssql.quarkus.container-image.tag=${project.version}
-%mssql.quarkus.container-image.name=process-persistence-mssql
-```
-
-### Oracle
 Different properties configured using the `oracle.quarkus.container-image` define image-related settings like
 group, registry, tag & name needed to build the image.
 
@@ -279,7 +271,6 @@ group, registry, tag & name needed to build the image.
 %oracle.quarkus.container-image.tag=${project.version}
 %oracle.quarkus.container-image.name=process-persistence-oracle
 ```
-
 ---
 
 ## Running

--- a/examples/process-persistence/README.md
+++ b/examples/process-persistence/README.md
@@ -30,25 +30,30 @@ example. You could find more details about that example from its README.
 ## Configuration
 
 As mentioned earlier, this example can be run in quarkus development mode and in container mode. In dev mode, the 
-example uses `h2` database by default. In container mode it can use `postgresql`, `mssql` or `oracle` databases.
+example uses `h2` database. In container mode it can use `postgresql`, `mssql` or `oracle` databases.
 
 The databases `postgresql`, `mssql`, `oracle` are paired with a maven profile and a quarkus profile which are tied together. 
-So in this example there are three maven profiles  `postgresql`, `mssql`  and `oracle` tied to quarkus profiles with similar 
-name. The `postgresql`, `mssql` and `oracle` profiles defines their own specific database dependencies and configurations 
-whereas the `container` dependency is configured by adding the `quarkus-container-image-jib` dependency to all the db profiles 
-which packs the example as a docker image.
+So in this example there are three maven profiles `postgresql`,`mssql` and `oracle` tied to quarkus profiles with similar 
+name.The `postgresql`,`mssql` and `oracle` profiles defines their own specific database dependencies and configurations.
 
 In Dev mode, Quarkus provides us with a zero config database out of the box, a feature referred to as Dev Services.
-The only configuration that needs to be defined is `dev.quarkus.datasource.db-kind=h2` and the only main dependency required 
-is the corresponding jdbc driver which is included along with the common dependencies. Don’t configure a database URL, username and password if you intend to use Dev 
-Services. So H2 is the default database for dev mode. The only dependency needed is h2 jdbc driver.
+The only main dependency required is the corresponding jdbc driver. Don’t configure a database URL, 
+username and password if you intend to use Dev Services.
 
-This is the configuration for H2
+Below are the dependency & configurations needed for H2 in dev mode.
+
+```
+<dependency>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-jdbc-h2</artifactId>
+</dependency>
+```
+
 ```
 %dev.quarkus.datasource.db-kind=h2
 %dev.quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY
-
 ```
+
 `quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY` is a generic property that is usually added
 to the database connection url. The flyway scripts defines tables with columns names like `key` and `value`. But
 these are reserved words when working with H2. So this property effectively allows to create columns with these
@@ -96,8 +101,23 @@ This is the maven profile for Postgresql
 </profile>
 ```
 The dependency needed are postgresql jdbc driver and `quarkus-container-image-jib`.
-The `quarkus-container-image-jib` is an extension for the Quarkus framework that enables 
+The `quarkus-container-image-jib` is an extension for the Quarkus framework that enables
 building container images using Jib and helps to build the optimized container images directly.
+
+These are the configurations for Postgresql
+```
+%postgresql.quarkus.datasource.db-kind=postgresql
+
+%postgresql.quarkus.container-image.build=true
+%postgresql.quarkus.container-image.push=false
+%postgresql.quarkus.container-image.group=bamoe
+%postgresql.quarkus.container-image.registry=dev.local
+%postgresql.quarkus.container-image.tag=${project.version}
+%postgresql.quarkus.container-image.name=process-persistence-postgresql
+```
+The `%postgresql.quarkus.datasource.db-kind` configuration property is used to explicitly specify the type of database to connect.
+Different properties configured using the `postgresql.quarkus.container-image` define image-related settings like
+group, registry, tag & name needed to build the image.
 
 ### MS SQL Server
 
@@ -116,7 +136,7 @@ This is the maven profile for MS SQL Server
         <dependency>
             <groupId>com.ibm.bamoe</groupId>
             <artifactId>bamoe-mssql-mappings</artifactId>
-            <version>${version.com.ibm.bamoe}</version>
+            <version>${version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -137,6 +157,22 @@ The available orm's are:
 Depending on the dependencies configured in our application it may be required to configure the ORMs to be used.
 To configure which mapping files should be imported you can use the `quarkus.hibernate-orm.mapping-files` property to 
 configure a comma-separated list of ORM files to use.
+
+These are the configurations required for Mssql
+```
+%mssql.quarkus.datasource.db-kind=mssql
+
+%mssql.quarkus.container-image.build=true
+%mssql.quarkus.container-image.push=false
+%mssql.quarkus.container-image.group=bamoe
+%mssql.quarkus.container-image.registry=dev.local
+%mssql.quarkus.container-image.tag=${project.version}
+%mssql.quarkus.container-image.name=process-persistence-mssql
+
+```
+The `%mssql.quarkus.datasource.db-kind` configuration property is used to explicitly specify the type of database to connect.
+Different properties configured using the `mssql.quarkus.container-image` define image-related settings like
+group, registry, tag & name needed to build the image.
 
 
 ### Oracle
@@ -178,14 +214,22 @@ Depending on the dependencies configured in our application it may be required t
 To configure which mapping files should be imported you can use the `quarkus.hibernate-orm.mapping-files` property to 
 configure a comma-separated list of ORM files to use.
 
-### Container
+These are the configurations required for Oracle
+```
+%oracle.quarkus.datasource.db-kind=oracle
 
-The `quarkus-container-image-jib` library is used to package the example as a docker image.
-The `container` related dependency `quarkus-container-image-jib` library is added in the corresponding 
-database profile like `postgresql` or `mssql`or`oracle` to pack related database dependencies and configurations. 
-The resulting image is then used in a docker compose file to run all services including this example, 
-database and any other database addon services together as containers.
-The docker compose files are located [here](docker-compose).
+%oracle.quarkus.container-image.build=true
+%oracle.quarkus.container-image.push=false
+%oracle.quarkus.container-image.group=bamoe
+%oracle.quarkus.container-image.registry=dev.local
+%oracle.quarkus.container-image.tag=${project.version}
+%oracle.quarkus.container-image.name=process-persistence-oracle
+
+```
+The `%oracle.quarkus.datasource.db-kind` configuration property is used to explicitly specify the type of database to connect.
+Different properties configured using the `oracle.quarkus.container-image` define image-related settings like
+group, registry, tag & name needed to build the image.
+
 
 ---
 
@@ -234,7 +278,7 @@ docker compose -f ./docker-compose/docker-compose-<dbtype>.yml down
 
 ### Running in Development mode
 
-The development mode in this application currently supports only `h2` database. The dev 
+The development mode in this application uses `h2` database. The dev 
 mode will embed all the needed Infrastructure Services (Database, Data-Index & Jobs Service) and won't require any 
 extra step. To start this example's app in Development mode , just run the following command in a terminal
 ```shell

--- a/examples/process-persistence/README.md
+++ b/examples/process-persistence/README.md
@@ -297,16 +297,7 @@ docker compose -f ./docker-compose/docker-compose-<dbtype>.yml down
 
 The development mode in this application currently supports only `h2` database. The dev 
 mode will embed all the needed Infrastructure Services (Database, Data-Index & Jobs Service) and won't require any 
-extra step. To start this example's app in Development mode with a specific database configuration, just run the 
-following command in a terminal
-```
-mvn clean package quarkus:dev -P<dbtype>
-```
-So for e.g. to start the example in dev mode using `h2` database configuration we can run the following command:
-```shell
-mvn clean package quarkus:dev -Ph2
-```
-If we don't specify a profile, database configurations of h2 is used by default in dev mode.
+extra step. To start this example's app in Development mode , just run the following command in a terminal
 ```shell
 mvn clean package quarkus:dev
 ```

--- a/examples/process-persistence/pom.xml
+++ b/examples/process-persistence/pom.xml
@@ -87,6 +87,7 @@
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-with-drools-quarkus</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-process-management</artifactId>

--- a/examples/process-persistence/pom.xml
+++ b/examples/process-persistence/pom.xml
@@ -114,10 +114,6 @@
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-persistence-jdbc</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-h2</artifactId>
-        </dependency>
 
         <!-- User Task Persistence -->
         <dependency>
@@ -153,6 +149,21 @@
     </dependencies>
 
     <profiles>
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <quarkus.profile>dev</quarkus.profile>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-jdbc-h2</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>postgresql</id>
             <properties>

--- a/examples/process-persistence/pom.xml
+++ b/examples/process-persistence/pom.xml
@@ -87,11 +87,6 @@
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-with-drools-quarkus</artifactId>
         </dependency>
-        <!-- Dev service- h2 dependency-->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jdbc-h2</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-process-management</artifactId>
@@ -117,6 +112,10 @@
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-persistence-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
         </dependency>
 
         <!-- User Task Persistence -->
@@ -182,6 +181,7 @@
                 <dependency>
                     <groupId>com.ibm.bamoe</groupId>
                     <artifactId>bamoe-mssql-mappings</artifactId>
+                    <version>${version}</version>
                 </dependency>
                 <dependency>
                     <groupId>io.quarkus</groupId>

--- a/examples/process-persistence/pom.xml
+++ b/examples/process-persistence/pom.xml
@@ -87,7 +87,11 @@
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-with-drools-quarkus</artifactId>
         </dependency>
-
+        <!-- Dev service- h2 dependency-->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-process-management</artifactId>
@@ -150,33 +154,6 @@
 
     <profiles>
         <profile>
-            <id>container</id>
-            <properties>
-                <quarkus.profile>container</quarkus.profile>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-container-image-jib</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>h2</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <quarkus.profile>h2</quarkus.profile>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-jdbc-h2</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>postgresql</id>
             <properties>
                 <quarkus.profile>postgresql</quarkus.profile>
@@ -185,6 +162,10 @@
                 <dependency>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-jdbc-postgresql</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
                 </dependency>
             </dependencies>
         </profile>
@@ -202,6 +183,10 @@
                     <groupId>com.ibm.bamoe</groupId>
                     <artifactId>bamoe-mssql-mappings</artifactId>
                 </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
+                </dependency>
             </dependencies>
         </profile>
          <profile>
@@ -218,6 +203,10 @@
                     <groupId>com.ibm.bamoe</groupId>
                     <artifactId>bamoe-oracle-mappings</artifactId> 
                     <version>${version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
                 </dependency>
             </dependencies>
         </profile>

--- a/examples/process-persistence/src/main/resources/application.properties
+++ b/examples/process-persistence/src/main/resources/application.properties
@@ -44,23 +44,22 @@ kogito.persistence.type=jdbc
 # use flyway
 quarkus.hibernate-orm.validate-in-dev-mode=false
 quarkus.hibernate-orm.database.generation=none
+quarkus.datasource.devservices.enabled=false
 
 # H2
 %dev.quarkus.datasource.db-kind=h2
+%dev.quarkus.datasource.devservices.enabled=true
 %dev.quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY
 
 # Postgres
 %postgresql.quarkus.datasource.db-kind=postgresql
-%postgresql.quarkus.datasource.devservices.enabled=false
 
 # Mssql
 %mssql.quarkus.datasource.db-kind=mssql
-%mssql.quarkus.datasource.devservices.enabled=false
 %mssql.quarkus.hibernate-orm.mapping-files=META-INF/bamoe-data-index-orm.xml,META-INF/bamoe-job-service-orm.xml
 
 # Oracle
 %oracle.quarkus.datasource.db-kind=oracle
-%oracle.quarkus.datasource.devservices.enabled=false
 %oracle.quarkus.hibernate-orm.mapping-files=META-INF/bamoe-user-task-orm.xml,META-INF/bamoe-job-service-orm.xml
 
 ############

--- a/examples/process-persistence/src/main/resources/application.properties
+++ b/examples/process-persistence/src/main/resources/application.properties
@@ -51,13 +51,16 @@ quarkus.hibernate-orm.database.generation=none
 
 # Postgres
 %postgresql.quarkus.datasource.db-kind=postgresql
+%postgresql.quarkus.datasource.devservices.enabled=false
 
 # Mssql
 %mssql.quarkus.datasource.db-kind=mssql
+%mssql.quarkus.datasource.devservices.enabled=false
 %mssql.quarkus.hibernate-orm.mapping-files=META-INF/bamoe-data-index-orm.xml,META-INF/bamoe-job-service-orm.xml
 
 # Oracle
 %oracle.quarkus.datasource.db-kind=oracle
+%oracle.quarkus.datasource.devservices.enabled=false
 %oracle.quarkus.hibernate-orm.mapping-files=META-INF/bamoe-user-task-orm.xml,META-INF/bamoe-job-service-orm.xml
 
 ############
@@ -69,6 +72,21 @@ quarkus.hibernate-orm.database.generation=none
 quarkus.oidc.enabled=false
 kogito.auth.enabled=false
 
+####################
+# Containerization #
+####################
+
+# Profile to pack this example into a container image.
+# To use it run a Maven build with the `container` profile (-Pcontainer)
+
+%postgresql,mssql,oracle.quarkus.container-image.build=true
+%postgresql,mssql,oracle.quarkus.container-image.push=false
+%postgresql,mssql,oracle.quarkus.container-image.group=bamoe
+%postgresql,mssql,oracle.quarkus.container-image.registry=dev.local
+%postgresql,mssql,oracle.quarkus.container-image.tag=${project.version}
+%postgresql.quarkus.container-image.name=process-persistence-postgresql
+%mssql.quarkus.container-image.name=process-persistence-mssql
+%oracle.quarkus.container-image.name=process-persistence-oracle
 
 
 ############

--- a/examples/process-persistence/src/main/resources/application.properties
+++ b/examples/process-persistence/src/main/resources/application.properties
@@ -44,11 +44,9 @@ kogito.persistence.type=jdbc
 # use flyway
 quarkus.hibernate-orm.validate-in-dev-mode=false
 quarkus.hibernate-orm.database.generation=none
-quarkus.datasource.devservices.enabled=false
 
 # H2
 %dev.quarkus.datasource.db-kind=h2
-%dev.quarkus.datasource.devservices.enabled=true
 %dev.quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY
 
 # Postgres

--- a/examples/process-persistence/src/main/resources/application.properties
+++ b/examples/process-persistence/src/main/resources/application.properties
@@ -46,7 +46,6 @@ quarkus.hibernate-orm.validate-in-dev-mode=false
 quarkus.hibernate-orm.database.generation=none
 quarkus.datasource.devservices.enabled=false
 
-
 # H2
 %h2.quarkus.datasource.db-kind=h2
 %h2.quarkus.datasource.devservices.enabled=true

--- a/examples/process-persistence/src/main/resources/application.properties
+++ b/examples/process-persistence/src/main/resources/application.properties
@@ -44,9 +44,12 @@ kogito.persistence.type=jdbc
 # use flyway
 quarkus.hibernate-orm.validate-in-dev-mode=false
 quarkus.hibernate-orm.database.generation=none
+quarkus.datasource.devservices.enabled=false
+
 
 # H2
 %h2.quarkus.datasource.db-kind=h2
+%h2.quarkus.datasource.devservices.enabled=true
 %h2.quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY
 
 # Postgres

--- a/examples/process-persistence/src/main/resources/application.properties
+++ b/examples/process-persistence/src/main/resources/application.properties
@@ -44,12 +44,10 @@ kogito.persistence.type=jdbc
 # use flyway
 quarkus.hibernate-orm.validate-in-dev-mode=false
 quarkus.hibernate-orm.database.generation=none
-quarkus.datasource.devservices.enabled=false
 
 # H2
-%h2.quarkus.datasource.db-kind=h2
-%h2.quarkus.datasource.devservices.enabled=true
-%h2.quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY
+%dev.quarkus.datasource.db-kind=h2
+%dev.quarkus.datasource.devservices.properties.NON_KEYWORDS=VALUE,KEY
 
 # Postgres
 %postgresql.quarkus.datasource.db-kind=postgresql
@@ -71,21 +69,6 @@ quarkus.datasource.devservices.enabled=false
 quarkus.oidc.enabled=false
 kogito.auth.enabled=false
 
-####################
-# Containerization #
-####################
-
-# Profile to pack this example into a container image.
-# To use it run a Maven build with the `container` profile (-Pcontainer)
-
-%container,postgresql,mssql,oracle.quarkus.container-image.build=true
-%container,postgresql,mssql,oracle.quarkus.container-image.push=false
-%container,postgresql,mssql,oracle.quarkus.container-image.group=bamoe
-%container,postgresql,mssql,oracle.quarkus.container-image.registry=dev.local
-%container,postgresql,mssql,oracle.quarkus.container-image.tag=${project.version}
-%postgresql.quarkus.container-image.name=process-persistence-postgresql
-%mssql.quarkus.container-image.name=process-persistence-mssql
-%oracle.quarkus.container-image.name=process-persistence-oracle
 
 
 ############


### PR DESCRIPTION
Fix Quarkus profiles in Process Persistence Example
Changes done are below
- Dev mode always uses h2
- Container mode can use rest of profiles (postgres, oracle, mssql)