### PR TITLE
NO-ISSUE: add HEALTHCHECK to maven-repository image

### DIFF
--- a/container-images/maven-repository/Containerfile
+++ b/container-images/maven-repository/Containerfile
@@ -32,5 +32,7 @@ EXPOSE $MAVEN_REPO_PORT
 # Change to a non root user
 USER 1000
 
+HEALTHCHECK --interval=1m --timeout=5s CMD curl -f http://localhost:$MAVEN_REPO_PORT/ || exit 1
+
 # Start httpd when the container launches
 CMD ["httpd", "-D", "FOREGROUND"]

--- a/container-images/maven-repository/Containerfile
+++ b/container-images/maven-repository/Containerfile
@@ -5,6 +5,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 ARG MAVEN_REPO_PORT=8080
 ARG MAVEN_REPO_FOLDER
 
+ENV MAVEN_REPO_PORT=$MAVEN_REPO_PORT
+
 # Install required packages: httpd and unzip, clean up after installation
 RUN microdnf --disableplugin=subscription-manager -y install httpd \
   && microdnf --disableplugin=subscription-manager clean all


### PR DESCRIPTION
Adding HEALTHCHECK to maven-repository image.

Rest of images should inherit the HEALTHCHECK from Apache KIE base images.